### PR TITLE
Updating the coffee-repl command

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -154,7 +154,7 @@ path."
      (apply 'make-comint "CoffeeREPL"
             coffee-command nil coffee-args-repl)))
 
-  (pop-to-buffer "*CoffeeScript*"))
+  (pop-to-buffer "*CoffeeREPL*"))
 
 (defun coffee-compile-file ()
   "Compiles and saves the current file to disk. Doesn't open in a buffer.."


### PR DESCRIPTION
Hello,

The coffee-repl command was issuing a pop-to-buffer call with the buffer name of '_CoffeeScript_', although the make-comint call was creating the buffer with the name of '_CoffeeREPL_' so the user was never switched to the repl.  I have included a patch to fix this.

Thanks,
Nick Parker
