### PR TITLE
Fix infinity loop in coffee-previous-indent

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -469,7 +469,7 @@ For detail, see `comment-dwim'."
     (if (bobp)
         0
       (progn
-        (while (coffee-line-empty-p) (forward-line -1))
+        (while (and (coffee-line-empty-p) (not (bobp))) (forward-line -1))
         (current-indentation)))))
 
 (defun coffee-line-empty-p ()


### PR DESCRIPTION
To reproduce this issue, press <tab> multiple times on first or second line at the coffee-mode buffer.
