### PR TITLE
Updated coffee-open-node-reference to open new docs location.

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -197,9 +197,9 @@ path."
   (browse-url "http://jashkenas.github.com/coffee-script/"))
 
 (defun coffee-open-node-reference ()
-  "Open browser to node.js reference."
+  "Open browser to node.js documentation."
   (interactive)
-  (browse-url "http://nodejs.org/api.html"))
+  (browse-url "http://nodejs.org/docs/"))
 
 (defun coffee-open-github ()
   "Open browser to `coffee-mode' project on GithHub."


### PR DESCRIPTION
Useful mode, thanks!
