### PR TITLE
Fix for regexp literals with slashes in brackets

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -250,7 +250,7 @@ path."
 (defvar coffee-boolean-regexp "\\b\\(true\\|false\\|yes\\|no\\|on\\|off\\|null\\)\\b")
 
 ;; Regular Expressions
-(defvar coffee-regexp-regexp "\\/\\([^\\]\\|\\\\.\\)+?\\/")
+(defvar coffee-regexp-regexp "\\/\\(\\\\.\\|\\[\\(\\\\.\\|.\\)+?\\]\\|[^/]\\)+?\\/")
 
 ;; JavaScript Keywords
 (defvar coffee-js-keywords


### PR DESCRIPTION
Regular Expression literal allows bare `/` in brackets like the example below, while coffee-mode highlights `/foo[/` as the separated regexp literal.

```
/foo[/]bar/
```
