### PR TITLE
Use “Coffee” as mode name rather than “coffee-mode”

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -564,8 +564,8 @@ line? Returns `t' or `nil'. See the README for more details."
 
 ;;;###autoload
 (define-derived-mode coffee-mode fundamental-mode
-  "coffee-mode"
-  "Major mode for editing CoffeeScript..."
+  "Coffee"
+  "Major mode for editing CoffeeScript."
 
   ;; key bindings
   (define-key coffee-mode-map (kbd "A-r") 'coffee-compile-buffer)


### PR DESCRIPTION
This just makes it look more professional, as it’s the standard Emacs style.
