### PR TITLE
Do not keep trailing whitespaces on newline

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -485,6 +485,7 @@ For detail, see `comment-dwim'."
   ;; insert a newline, and indent the newline to the same
   ;; level as the previous line.
   (let ((prev-indent (current-indentation)) (indent-next nil))
+    (delete-horizontal-space t)
     (newline)
     (insert-tab (/ prev-indent coffee-tab-width))
 


### PR DESCRIPTION
If you press enter, coffee-mode will leave whitespace used for indent in place. This patch makes `coffee-newline-and-indent` behave like regular `newline-and-indent`.
