### PR TITLE
Hilight coffee-lambda-regexp w/ font-lock-preprocessor-face

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -290,7 +290,9 @@ path."
     (,coffee-assign-regexp . font-lock-type-face)
     (,coffee-regexp-regexp . font-lock-constant-face)
     (,coffee-boolean-regexp . font-lock-constant-face)
-    (,coffee-keywords-regexp . font-lock-keyword-face)))
+    (,coffee-keywords-regexp . font-lock-keyword-face)
+    (,coffee-lambda-regexp . font-lock-preprocessor-face)
+    ))
 
 ;;
 ;; Helper Functions


### PR DESCRIPTION
My CoffeeScript friends were making fun of me because functions were not rendered in a different color, opposed to their pretty GEdit/Kate. This change fixed it for me. :-)
