### PR TITLE
Auto-indent doesn't work when tab width is set

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -292,7 +292,7 @@ If FILENAME is omitted, the current buffer's file name is used."
   `((,coffee-string-regexp . font-lock-string-face)
     (,coffee-this-regexp . font-lock-variable-name-face)
     (,coffee-prototype-regexp . font-lock-variable-name-face)
-    (,coffee-assign-regexp . font-lock-type-face)
+    (,coffee-assign-regexp . font-lock-function-name-face)
     (,coffee-regexp-regexp . font-lock-constant-face)
     (,coffee-boolean-regexp . font-lock-constant-face)
     (,coffee-keywords-regexp . font-lock-keyword-face)))


### PR DESCRIPTION
- Fixing an issue that would disable autoindenting when custom tab width is set

Dug this up in the history. Fixes #38.
