### PR TITLE
Allow existing `coffee-args-compile` to be used for all compile functions

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -183,10 +183,10 @@ If FILENAME is omitted, the current buffer's file name is used."
     (when buffer
       (kill-buffer buffer)))
 
-  (call-process-region start end coffee-command nil
-                       (get-buffer-create coffee-compiled-buffer-name)
-                       nil
-                       "-s" "-p" "--bare")
+  (apply (apply-partially 'call-process-region start end coffee-command nil
+                          (get-buffer-create coffee-compiled-buffer-name)
+                          nil)
+         (append coffee-args-compile (list "-s" "-p")))
   (switch-to-buffer (get-buffer coffee-compiled-buffer-name))
   (funcall coffee-js-mode)
   (goto-char (point-min)))


### PR DESCRIPTION
Currently, the customizable `coffee-args-compile` is only taken into account when compiling files. This pull request edits the `coffee-compile-region` function to use the `coffee-args-compile` var when compiling regions/buffers, but still hard-codes the `-s` and `-p` options so that the functionality works as expected within Emacs.

This refers to [Issue #40](https://github.com/defunkt/coffee-mode/issues/40)
