### PR TITLE
Add support for Cygwin-style absolute paths on Windows Systems

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -329,12 +329,17 @@ For detail, see `comment-dwim'."
   "Given an expanded file name, derive the absolute Cygwin path based on `coffee-cygwin-prefix'."
   (replace-regexp-in-string "^[a-zA-Z]:" coffee-cygwin-prefix expanded-file-name t))
 
+(defun coffee-universal-path (file-name)
+  "Handle different paths for different OS configurations for CoffeeScript"
+  (let ((full-file-name (expand-file-name file-name)))
+    (if (and (equal system-type 'windows-nt)
+             coffee-cygwin-mode)
+        (coffee-cygwin-path full-file-name)
+      full-file-name)))
+
 (defun coffee-command-compile (file-name)
   "The `coffee-command' with args to compile a file."
-  (let ((full-file-name (if (and (equal system-type 'windows-nt)
-                                 coffee-cygwin-mode)
-                            (coffee-cygwin-path (expand-file-name file-name))
-			  (expand-file-name file-name))))
+  (let ((full-file-name (coffee-universal-path file-name)))
     (mapconcat 'identity (append (list coffee-command) coffee-args-compile (list full-file-name)) " ")))
 
 ;;


### PR DESCRIPTION
This pull request addresses [Issue #37](https://github.com/defunkt/coffee-mode/issues/37)

Obviously it is customary to run CoffeeScript under Node.js. For Windows users, it is common to compile Node.js with Cygwin in order to use CoffeeScript. However, Cygwin expects it's own style of absolute paths (prefixed with `/cygdrive/C`), which of course `expand-file-name` does not expand to. Given these restrictions, **at the present time coffee-mode's file compilation functionality does not work on Windows.**

I've implemented three things:
- A `coffee-cygwin-mode` customizable var, for enabling/disabling support for Cygwin-style paths on Windows for CoffeeScript commands
- A `coffee-cygwin-prefix` customizable var, to allow people to set `/cygdrive/C` to whatever their Cygwin expects to see (dependent on installation)
- A `coffee-cygwin-path` function, which given an expanded file name will return a Cygwin-style absolute path + file name

Finally, I tweaked `coffee-command-compile` to leverage these settings when the `system-type` is `windows-nt`.

Without these changes, this mode's file compilation functionality does not work on Windows for the "canonical" setup of CoffeeScript on Node.js.
