### PR TITLE
Add support for coffee --watch

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -114,6 +114,11 @@ path."
   :type 'string
   :group 'coffee)
 
+(defcustom coffee-watch-buffer-name "*coffee-watch*"
+  "The name of the scratch buffer used when using the --watch flag with  CoffeeScript."
+  :type 'string
+  :group 'coffee)
+
 (defvar coffee-mode-hook nil
   "A hook for you to run your own code when the mode is loaded.")
 
@@ -210,6 +215,13 @@ If FILENAME is omitted, the current buffer's file name is used."
   "Open browser to `coffee-mode' project on GithHub."
   (interactive)
   (browse-url "http://github.com/defunkt/coffee-mode"))
+
+(defun coffee-watch (dir-or-file)
+  "Run `coffee-run-cmd' with the --watch flag enabled for a directory or file"
+  (interactive "fDirectory or File: ")
+  (let ((coffee-compiled-buffer-name coffee-watch-buffer-name)
+        (args (mapconcat 'identity (append coffee-args-compile (list "--watch" (expand-file-name dir-or-file))) " ")))
+    (coffee-run-cmd args)))
 
 ;;
 ;; Menubar
@@ -318,6 +330,13 @@ For detail, see `comment-dwim'."
 (defun coffee-command-compile (file-name)
   "The `coffee-command' with args to compile a file."
   (mapconcat 'identity (append (list coffee-command) coffee-args-compile (list file-name)) " "))
+
+(defun coffee-run-cmd (args)
+  "Given an arbitrary set of arguments for the `coffee-command', compile the command and show output in a custom compilation buffer."
+  (interactive "sArguments: ")
+  (let ((compilation-buffer-name-function (lambda (this-mode)
+                                            (generate-new-buffer-name coffee-compiled-buffer-name))))
+    (compile (concat coffee-command " " args))))
 
 ;;
 ;; imenu support


### PR DESCRIPTION
I've implemented an interactive function `coffee-watch` that takes either a directory or file name, opens up a custom compilation buffer and runs `coffee --watch` against the directory/file entered. This works as expected.

In the process of supporting this, I also implemented a generic `coffee-run-cmd` function, which takes any arbitrary arguments to the `coffee` command, opens up a custom compilation buffer and runs the command. By default, I use `coffee-compiled-buffer-name` for the name of the compilation buffer, and added a new customizable var `coffee-watch-buffer-name` for the `coffee-watch` custom compilation buffer name.

I did _not_ include support for the Windows/Cygwin stuff I've requested in other pull requests, though I do have it ready for this pull request as well, if/when you accept my previous pull request.

Thanks for your consideration of my additions!
