### PR TITLE
Fixed tabbing issue where coffee-tab-width was used in some places and global tab-width in others

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -596,6 +596,7 @@ line? Returns `t' or `nil'. See the README for more details."
   ;; indentation
   (make-local-variable 'indent-line-function)
   (setq indent-line-function 'coffee-indent-line)
+  (set (make-local-variable 'tab-width) coffee-tab-width)
 
   ;; imenu
   (make-local-variable 'imenu-create-index-function)


### PR DESCRIPTION
Small patch to fix indentation behavior; before, the global tab-width setting is used when inserting tabs with insert-tab, e.g. at the top of coffee-newline-and-insert.  I used 'customize-group coffee' to set my coffee-tab-width to 2, but I have a global tab width of 4, so the net effect was that the number of tabs would be halved every time I hit return.

With this one-line patch, typing 'M-x customize-group' and then 'coffee' to edit 'coffee-tab-width' (or putting (custom-set-variables '(coffee-tab-width 2)) in your .emacs file) should work right.
