### PR TITLE
Removed extra parens in example hook.

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,14 +231,14 @@ Naturally. Example:
       (define-key coffee-mode-map [(meta r)] 'coffee-compile-buffer)
 
       ;; Riding edge.
-      (setq coffee-command "~/dev/coffee"))
+      (setq coffee-command "~/dev/coffee")
 
       ;; Compile '.coffee' files on every save
       (and (file-exists-p (buffer-file-name))
            (file-exists-p (coffee-compiled-file-name))
-           (coffee-cos-mode t))))
+           (coffee-cos-mode t)))
 
-    (add-hook 'coffee-mode-hook 'coffee-custom))
+    (add-hook 'coffee-mode-hook 'coffee-custom)
 
 ## Configuration
 


### PR DESCRIPTION
Also, it might be good to note what the prefix A- means in a key binding, since it's not something I've seen before and doesn't seem to be easily Google-able. 
