### PR TITLE
Fix syntax highlighting for variables containing keywords bounded by underscores.

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -676,6 +676,9 @@ line? Returns `t' or `nil'. See the README for more details."
   ;; code for syntax highlighting
   (setq font-lock-defaults '((coffee-font-lock-keywords)))
 
+  ;; treat "_" as part of a word
+  (modify-syntax-entry ?_ "w" coffee-mode-syntax-table)
+
   ;; perl style comment: "# ..."
   (modify-syntax-entry ?# "< b" coffee-mode-syntax-table)
   (modify-syntax-entry ?\n "> b" coffee-mode-syntax-table)


### PR DESCRIPTION
Tokens such as 'my_new_variable' were being highlighted in two different colors.

This redefines the definition of the word syntax class, so if you like to M-f or M-b through your code you'll notice you skip over the underscores now. If this is a problem, maybe a defcustom toggling the redefinition is appropriate?
