### PR TITLE
add 'undefined' as a reserved word

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -324,7 +324,7 @@ If FILENAME is omitted, the current buffer's file name is used."
 (defvar coffee-namespace-regexp "\\b\\(class\\s +\\(\\S +\\)\\)\\b")
 
 ;; Booleans
-(defvar coffee-boolean-regexp "\\b\\(true\\|false\\|yes\\|no\\|on\\|off\\|null\\)\\b")
+(defvar coffee-boolean-regexp "\\b\\(true\\|false\\|yes\\|no\\|on\\|off\\|null\\|undefined\\)\\b")
 
 ;; Regular Expressions
 (defvar coffee-regexp-regexp "\\/\\(\\\\.\\|\\[\\(\\\\.\\|.\\)+?\\]\\|[^/]\\)+?\\/")


### PR DESCRIPTION
adding undefined to reserved words as part of coffee-boolean-regexp (not a proper boolean, but seemed the best fit)
