### PR TITLE
Remap newline-and-indent to coffee-newline-and-indent

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -670,6 +670,7 @@ line? Returns `t' or `nil'. See the README for more details."
   (define-key coffee-mode-map (kbd "A-R") 'coffee-compile-region)
   (define-key coffee-mode-map (kbd "A-M-r") 'coffee-repl)
   (define-key coffee-mode-map [remap comment-dwim] 'coffee-comment-dwim)
+  (define-key coffee-mode-map [remap newline-and-indent] 'coffee-newline-and-indent)
   (define-key coffee-mode-map "\C-m" 'coffee-newline-and-indent)
   (define-key coffee-mode-map "\C-c\C-o\C-s" 'coffee-cos-mode)
 


### PR DESCRIPTION
Does what it says on the package.

Not all emacs users use enter when coding, by default, C-j is bound to newline-and-indent.

This commit remaps newline-and-indent to use the coffee-mode version, so anyone that has a habit of using C-j can happily continue to do so and still have nice indentation.
