### PR TITLE
stop regexp-regexp from badly hanging during syntax highlighting

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -327,7 +327,8 @@ If FILENAME is omitted, the current buffer's file name is used."
 (defvar coffee-boolean-regexp "\\b\\(true\\|false\\|yes\\|no\\|on\\|off\\|null\\|undefined\\)\\b")
 
 ;; Regular Expressions
-(defvar coffee-regexp-regexp "\\/\\(\\\\.\\|\\[\\(\\\\.\\|.\\)+?\\]\\|[^/]\\)+?\\/")
+(defvar coffee-regexp-regexp "\\/\\(\\\\.\\|\\[\\(\\\\.\\|.\\)+?\\]\\|[^/
+]\\)+?\\/")
 
 ;; JavaScript Keywords
 (defvar coffee-js-keywords


### PR DESCRIPTION
Quick fix for Issue #56.  Changes coffee-regexp-regexp so that syntax highlighting doesn't try to match regexp / ... / expressions across newlines. In elisp regexps [^/] will match newlines unless one adds a newline between the brackets.  Given the two nested non-greedy general regexps this was causing massive hangups that required killing the emacs process to stop!
