### PR TITLE
Fix for issue #63

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -636,9 +636,10 @@ line? Returns `t' or `nil'. See the README for more details."
         (end-of-line)
 
         ;; Optimized for speed - checks only the last character.
-        (when (some (lambda (char)
-                        (= (char-before) char))
-                      coffee-indenters-eol)
+        (when (and (char-before)
+                   (some (lambda (char)
+                           (= (char-before) char))
+                         coffee-indenters-eol))
           (setd indenter-at-eol t)))
 
       ;; If we found an indenter, return `t'.


### PR DESCRIPTION
Fixes exception thrown when the user hits enter at the beginning of the buffer.  Previously, coffee-mode was trying to compare char-before to a list of eol characters, but at the beginning of the buffer, char-before is niil.
