### PR TITLE
Workaround to avoid getting garbage chars in the comint buffer.

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -196,7 +196,8 @@ was called."
   (unless (comint-check-proc "*CoffeeREPL*")
     (set-buffer
      (apply 'make-comint "CoffeeREPL"
-            coffee-command nil coffee-args-repl)))
+            "env"
+            nil (append (list "NODE_NO_READLINE=1" coffee-command) coffee-args-repl))))
 
   (pop-to-buffer "*CoffeeREPL*"))
 


### PR DESCRIPTION
I had the same problem as issue #30, and found this suggestion (http://stackoverflow.com/questions/6605058/what-are-these-shell-escape-characters) that node's use of readline might have something to do with it. I whipped up this workaround, which seems to do the trick, at least for me.
