### PR TITLE
Mark member at point and colorize lambdas

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -232,6 +232,7 @@ The member marked is the one returned by `which-function'."
               (when (>= (line-number-at-pos) lines)
                 (throw 'break nil)))
             (forward-line 1))))
+      (end-of-line)
       (set-mark (min (point-max) (point)))
       (goto-char beg))))
 


### PR DESCRIPTION
I added a `coffee-mark-member` defun to select the member function at the point's location using `which-function`. It is bound to `C-c m`.

I also added a font lock keyword for lambdas so that `->` and `=>` get the function name face.
