### PR TITLE
Fix for keyword syntax highlighting issue - does not change what constitutes a 'word' in the mode

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -565,7 +565,6 @@ previous line."
   ;; perl style comment: "# ..."
   (modify-syntax-entry ?# "< b" coffee-mode-syntax-table)
   (modify-syntax-entry ?\n "> b" coffee-mode-syntax-table)
-  (modify-syntax-entry ?_ "w" coffee-mode-syntax-table)
   (make-local-variable 'comment-start)
   (setq comment-start "#")
 


### PR DESCRIPTION
Currently keywords are being highlighted inside variable names. e.g. if I create a variable called 'import_button', 'import' will be highlighted.

This fixes the issue without modifying the syntax table's word class throughout the mode. (i.e. forward-word, etc. will still operate in terms of words inside the variable names, rather than the whole variable names).
