### PR TITLE
Compiled coffee buffer pop instead of switch

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -289,7 +289,7 @@ called `coffee-compiled-buffer-name'."
                           (get-buffer-create coffee-compiled-buffer-name)
                           nil)
          (append coffee-args-compile (list "-s" "-p")))
-  (switch-to-buffer (get-buffer coffee-compiled-buffer-name))
+  (pop-to-buffer (get-buffer coffee-compiled-buffer-name))
   (let ((buffer-file-name "tmp.js")) (set-auto-mode))
   (goto-char (point-min)))
 


### PR DESCRIPTION
I believe the current behaviour is obstrusive, as the current buffer switch to the compiled buffer.
It could just be popped instead, so, here is my PR!
