### PR TITLE
Compiled coffee buffer : remove focus & kill

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -283,15 +283,18 @@ called `coffee-compiled-buffer-name'."
 
   (let ((buffer (get-buffer coffee-compiled-buffer-name)))
     (when buffer
-      (kill-buffer buffer)))
+      (with-current-buffer buffer
+        (erase-buffer))))
 
   (apply (apply-partially 'call-process-region start end coffee-command nil
                           (get-buffer-create coffee-compiled-buffer-name)
                           nil)
          (append coffee-args-compile (list "-s" "-p")))
-  (pop-to-buffer (get-buffer coffee-compiled-buffer-name))
-  (let ((buffer-file-name "tmp.js")) (set-auto-mode))
-  (goto-char (point-min)))
+
+  (let ((buffer (get-buffer coffee-compiled-buffer-name)))
+    (display-buffer buffer)
+    (with-current-buffer buffer
+      (let ((buffer-file-name "tmp.js")) (set-auto-mode)))))
 
 (defun coffee-js2coffee-replace-region (start end)
   "Convert JavaScript in the region into CoffeeScript."


### PR DESCRIPTION
I have submitted a PR few days ago that was replacing `switch-to-buffer` with `pop-to-buffer`. I think I have a better scenario:

As the user just wants to see the compiled code and never edit it, there is no need to give the focus to the compiled buffer.

And I saw a problem with `pop-to-buffer` (from the doc):

> Select buffer BUFFER-OR-NAME in some window, preferably a different one.

So the compiled buffer, even if displayed in a window, could move to another. I believe this is an unexpected behaviour.
