### PR TITLE
Fix for bytecompiling warnings

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -251,12 +251,15 @@ with CoffeeScript."
   (pop-to-buffer "*CoffeeREPL*"))
 
 (defun coffee-compiled-file-name (&optional filename)
-  (setq working-on-file (expand-file-name (or filename (buffer-file-name))))
-  (unless (string= coffee-js-directory "")
-      (setq working-on-file (expand-file-name (concat (file-name-directory working-on-file) coffee-js-directory (file-name-nondirectory working-on-file)))))
-  "Returns the name of the JavaScript file compiled from a CoffeeScript file.
-If FILENAME is omitted, the current buffer's file name is used."
-  (concat (file-name-sans-extension working-on-file) ".js"))
+  (let ((working-on-file (expand-file-name (or filename (buffer-file-name)))))
+    (unless (string= coffee-js-directory "")
+      (setq working-on-file
+            (expand-file-name (concat (file-name-directory working-on-file)
+                                      coffee-js-directory
+                                      (file-name-nondirectory working-on-file)))))
+    ;; Returns the name of the JavaScript file compiled from a CoffeeScript file.
+    ;; If FILENAME is omitted, the current buffer's file name is used.
+    (concat (file-name-sans-extension working-on-file) ".js")))
 
 (defun coffee-compile-file ()
   "Compiles and saves the current file to disk in a file of the same
@@ -833,7 +836,7 @@ END lie."
               (progn
                 (coffee-block-comment-delimiter match)
                 (goto-char match)
-                (next-line)
+                (forward-line)
                 (coffee-propertize-function (point) end))))))))
 
 ;;;###autoload


### PR DESCRIPTION
I got following warnings at byte compiling.
I fix for no warnings.

```
Compiling file /home/syohei/tmp/gomi/coffee-mode.el at Fri Jan 25 23:57:09 2013
Entering directory `/home/syohei/tmp/gomi/'

In coffee-compiled-file-name:
coffee-mode.el:256:13:Warning: assignment to free variable `working-on-file'
coffee-mode.el:256:76:Warning: reference to free variable `working-on-file'

In coffee-propertize-function:
coffee-mode.el:835:28:Warning: `next-line' used from Lisp code
That command is designed for interactive use only
```

Please review this patch.
