### PR TITLE
Disable regexp highlighting entirely for now.

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -885,7 +885,8 @@ END lie."
   (modify-syntax-entry ?\n "> b" coffee-mode-syntax-table)
 
   ;; Treat regular expressions as strings.
-  (modify-syntax-entry ?/ "|" coffee-mode-syntax-table)
+  ;; FIXME: Causes everything following division to be highlighted as a string.
+  ;(modify-syntax-entry ?/ "|" coffee-mode-syntax-table)
 
   (set (make-local-variable 'comment-start) "#")
 


### PR DESCRIPTION
See https://github.com/defunkt/coffee-mode/commit/be60c13#L0R885

This PR disables regexp highlighting entirely, because reverting brings back #110, but I know that this is not ideal. Wish I had strong enough Emacs Lisp chops to produce a solution. Perhaps `syntax-propertize-extend-region-functions` / `syntax-propertize-function` could be of help?
