### PR TITLE
Regexp as paired delimiters

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -451,6 +451,8 @@ called `coffee-compiled-buffer-name'."
     (,coffee-keywords-regexp 1 font-lock-keyword-face)
     (,coffee-string-interpolation-regexp 0 font-lock-variable-name-face t)))
 
+(font-lock-add-keywords 'coffee-mode '(("\\s$.*\\s$" 0 'font-lock-constant-face)))
+
 ;;
 ;; Helper Functions
 ;;
@@ -885,9 +887,8 @@ END lie."
   (modify-syntax-entry ?# "< b" coffee-mode-syntax-table)
   (modify-syntax-entry ?\n "> b" coffee-mode-syntax-table)
 
-  ;; Treat regular expressions as strings.
-  ;; FIXME: Causes everything following division to be highlighted as a string.
-  ;(modify-syntax-entry ?/ "|" coffee-mode-syntax-table)
+  ;; Treat slashes as paired delimiters; useful for finding regexps.
+  (modify-syntax-entry ?/ "$" coffee-mode-syntax-table)
 
   (set (make-local-variable 'comment-start) "#")
 


### PR DESCRIPTION
[EDIT: Closed because I accidentally included some unrelated commits. Opened #125]

Here's an idea for highlighting regexps: classify them as paired delimiters, which the Emacs Lisp manual describes as:

> Similar to string quote characters, except that the syntactic properties of the characters between the delimiters are not suppressed. Only TeX mode uses a paired delimiter presently—the ‘$’ that both enters and leaves math mode. 

Maybe this is nutty, I don't know. It seems to work fine with the following example:

```
re        = /thing to be found/
brokenRe  = /thing#/
string    = "string"
division  = 1 / 0
# Comment /regex/
```

And doesn't regress #110.

My Emacs Lisp fell short of getting this highlighting to work by adding a var to `coffee-font-lock-keywords` like all the other regexps, so I kind of brute-forced it with `font-lock-add-keywords` but maybe someone with more skill can use this as inspiration to do it correctly!
