### PR TITLE
Use `shell-command-on-region` rather than `call-process-region`

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -324,10 +324,10 @@ called `coffee-compiled-buffer-name'."
       (with-current-buffer buffer
         (erase-buffer))))
 
-  (apply (apply-partially 'call-process-region start end coffee-command nil
-                          (get-buffer-create coffee-compiled-buffer-name)
-                          nil)
-         (append coffee-args-compile (list "-s" "-p")))
+  (let ((command (format "%s %s -s -p" coffee-command
+                         (mapconcat 'identity coffee-args-compile " "))))
+    (shell-command-on-region start end command
+                             (get-buffer-create coffee-compiled-buffer-name)))
 
   (let ((buffer (get-buffer coffee-compiled-buffer-name)))
     (display-buffer buffer)


### PR DESCRIPTION
Windows seems to have problems with `call-process-region`; I'm
finding that files compile 'empty' (I see the wrapping IIFE with
no compiled code inside).

Is there any reason not to use the simpler `shell-command-on-region`?
