### PR TITLE
Navigation and hs minor mode support

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -992,6 +992,12 @@ END lie."
   (set (make-local-variable 'electric-indent-functions)
        (list (lambda (arg) 'no-indent)))
 
+  ;; support for hs-minor-mode
+  (add-to-list 'hs-special-modes-alist
+             `(coffee-mode "\\s-*\\(?:class\\|.+[-=]>$\\)" nil "#"
+                           ,(lambda (arg)
+                              (coffee-nav-end-of-block)) nil))
+
   ;; no tabs
   (setq indent-tabs-mode nil))
 


### PR DESCRIPTION
This pull request provides support for navigating around coffee-files.

It provides 2 functions to move to the end and beginning of blocks

Using this I was able to support hs-minor-mode as well.

Feedback would be greatly appreciated to get this into the mode.
