### PR TITLE
Fix block comment highlighting

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -860,7 +860,7 @@ END lie."
   (progn
     (goto-char match)
     (beginning-of-line)
-    (add-text-properties (point) (+ (point) 1) `(coffee-mode-syntax-table (14 . nil)))))
+    (add-text-properties (point) (+ (point) 1) `(syntax-table (14 . nil)))))
 
 ;; support coffescript block comments
 ;; examples:


### PR DESCRIPTION
Block comment content is currently not being highlighted as such, but is treated as code, which seems to be the result of a search-and-replace mistake. This commit fixes that.
