### PR TITLE
Fix highlighting local assignment without spaces

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -413,7 +413,7 @@ called `coffee-compiled-buffer-name'."
 (defvar coffee-assign-regexp "\\(\\(\\w\\|\\.\\|$\\)+?\s*\\):")
 
 ;; Local Assignment
-(defvar coffee-local-assign-regexp "\\(?:^\\|\\s-\\)\\(\\(\\w\\|\\$\\)+\\)\s+=[^>]")
+(defvar coffee-local-assign-regexp "\\(?:^\\|\\s-\\)\\(\\(\\w\\|\\$\\)+\\)\\s-*=[^>]")
 
 ;; Lambda
 (defvar coffee-lambda-regexp "\\((.+)\\)?\\s *\\(->\\|=>\\)")


### PR DESCRIPTION
Original code, `foo` of `foo = 10` is highlighted, but `foo` of `foo= 10` is not highlighted.
Because original regexp requires one more spaces left of `=` operator. I fixed that regexp.

Please see this patch.
