### PR TITLE
Fix highlighting regexp literal

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -425,7 +425,7 @@ called `coffee-compiled-buffer-name'."
 (defvar coffee-boolean-regexp "\\b\\(true\\|false\\|yes\\|no\\|on\\|off\\|null\\|undefined\\)\\b")
 
 ;; Regular expressions
-(defvar coffee-regexp-regexp "\\s$\\(.*\\)\\s$")
+(defvar coffee-regexp-regexp "\\s$\\(\\(?:\\\\/\\|[^/\n\r]\\)*\\)\\s$")
 
 ;; String Interpolation(This regexp is taken from ruby-mode)
 (defvar coffee-string-interpolation-regexp "#{[^}\n\\\\]*\\(?:\\\\.[^}\n\\\\]*\\)*}")

--- a/test/highlight.el
+++ b/test/highlight.el
@@ -421,13 +421,19 @@ after_comment
 (ert-deftest regular-expression-with-slash-in-same-line ()
   "Regular expression with slash in same line"
   (with-coffee-temp-buffer
-    "bar = replace /foo/ig, \"<b>bar</b>\""
+    "
+bar = replace /foo/ig, \"<b>bar</b>\"
+baz = \"</span>\""
     (forward-cursor-on "foo")
     (should (face-at-cursor-p 'font-lock-constant-face))
 
     (forward-cursor-on "bar")
     (should-not (face-at-cursor-p 'font-lock-constant-face))
-    (should (face-at-cursor-p 'font-lock-string-face))))
+    (should (face-at-cursor-p 'font-lock-string-face))
+
+    ;; check for syntax-propertize-function
+    (forward-cursor-on "baz")
+    (should-not (face-at-cursor-p 'font-lock-string-face))))
 
 (ert-deftest regular-expression-with-escape-slash ()
   "Regular expression with escape slash"


### PR DESCRIPTION
Original code highlights regexp wrong if another '/' is existed in same line,
such as:

``` coffee
   emit = emit.replace /hubot/ig, "<b>#{robot.name}</b>"
```

Original code treats `/hubot/ig, "<b>#{robot.name}</` as regexp literal.
Because it uses greedy matching.
### Original code highlighting

![orig-regexp-literal](https://f.cloud.github.com/assets/554281/1693328/f57d3aa0-5e8c-11e3-9c80-aa5ee78326fa.png)
### Fixed version highlighting

![fixed-regexp-literal](https://f.cloud.github.com/assets/554281/1693330/045e151c-5e8d-11e3-8460-2575e1b31721.png)

Please see this patch.
