### PR TITLE
Propertize content of regexp as 'symbol'(#163)

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -891,7 +891,7 @@ comments such as the following:
   (if (fboundp 'prog-mode) 'prog-mode 'fundamental-mode))
 
 (defvar coffee-propertize-via-font-lock
-  `((,coffee-regexp-regexp (1 (2 . nil)))
+  `((,coffee-regexp-regexp (1 (string-to-syntax "_")))
     ("^[[:space:]]*###\\([[:space:]]+.*\\)?$" (0 (14 . nil)))))
 
 ;;;###autoload


### PR DESCRIPTION
Original code, coffee-mode.el propertize it as 'word'.
This cause hung up problem #163.
