### PR TITLE
Create index for declaration with prototype access

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -532,7 +532,7 @@ output in a compilation buffer."
           "\\|"
           coffee-namespace-regexp ; $4
           "\\|"
-          coffee-local-assign-regexp ; $5
+          "\\([[:word:]:.$]+\\)\\s-*=\\(?:[^>]\\|$\\)" ; $5 match prototype access too
           "\\(?:" "\\s-*" "\\(" coffee-lambda-regexp "\\)" "\\)?" ; $6
           "\\)"))
 

--- a/test/imenu.el
+++ b/test/imenu.el
@@ -138,4 +138,23 @@ named_func = (x, y) ->
                       for assign = (car index)
                       thereis (string= assign expected)))))))
 
+(ert-deftest prototype-access-declaration ()
+  "Prototype access function declaration"
+  (with-coffee-temp-buffer
+    "
+Coffee::foo = (a, b) ->
+  a + b
+
+Coffee::bar =
+  minus: (x, y) -> x - y
+  block: ->
+    print('potion')
+"
+    (let ((got (coffee-imenu-create-index)))
+      (should (= (length got) 3))
+      (dolist (expected '("Coffee::foo" "Coffee::bar.minus" "Coffee::bar.block"))
+        (should (loop for index in got
+                      for assign = (car index)
+                      thereis (string= assign expected)))))))
+
 ;;; imenu.el end here


### PR DESCRIPTION
Create imenu indices `Coffee::foo`, `Coffee::bar.minux`, `Coffee::bar.block` from following code.

``` coffee
Coffee::foo = (a, b) ->
  a + b

Coffee::bar =
  minus: (x, y) -> x - y
  block: ->
    print('potion')
```
