### PR TITLE
Fix invalid highlighting regexp literal

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -973,6 +973,14 @@ comments such as the following:
    (syntax-propertize-rules
     (coffee-block-strings-delimiter
      (0 (ignore (coffee-syntax-block-strings-stringify))))
+    ("\\(?:[^\\]\\)\\(/\\)"
+     (1 (ignore
+         (let ((ppss (progn
+                       (goto-char (match-beginning 1))
+                       (syntax-ppss))))
+           (when (nth 8 ppss)
+             (put-text-property (match-beginning 1) (match-end 1)
+                                'syntax-table (string-to-syntax "_")))))))
     (coffee-regexp-regexp (1 (string-to-syntax "_")))
     ("^[[:space:]]*\\(###\\)\\(?:[[:space:]]+.*\\)?$"
      (1 (string-to-syntax "!"))))

--- a/test/highlight.el
+++ b/test/highlight.el
@@ -504,6 +504,16 @@ baz = \"</span>\""
     (forward-cursor-on "bar")
     (should (face-at-cursor-p 'font-lock-constant-face))))
 
+(ert-deftest regular-expression-with-double-quoted-slash ()
+  "Regular expression with double quoted slash"
+  (with-coffee-temp-buffer
+    "foo += \"/\" unless /bar/"
+    (forward-cursor-on "unless")
+    (should-not (face-at-cursor-p 'font-lock-constant-face))
+
+    (forward-cursor-on "bar")
+    (should (face-at-cursor-p 'font-lock-constant-face))))
+
 ;;
 ;; Block Strings(#159)
 ;;


### PR DESCRIPTION
Please review this patch
### before

![coffee-regexp-before](https://f.cloud.github.com/assets/554281/1754749/06f616bc-6658-11e3-9117-693cc8e33b7b.png)
### after

![coffee-regexp-highlight](https://f.cloud.github.com/assets/554281/1754751/0a7f3566-6658-11e3-8f58-0d5d711d4a84.png)
