### PR TITLE
Indent continued comment line

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -639,13 +639,15 @@ output in a compilation buffer."
 
     ;; We need to insert an additional tab because the last line was special.
     (when (coffee-line-wants-indent)
-      (insert-tab)))
+      (insert-tab))
 
-  ;; Last line was a comment so this one should probably be,
-  ;; too. Makes it easy to write multi-line comments (like the one I'm
-  ;; writing right now).
-  (when (coffee-previous-line-is-single-line-comment)
-    (insert "# ")))
+    ;; Last line was a comment so this one should probably be,
+    ;; too. Makes it easy to write multi-line comments (like the one I'm
+    ;; writing right now).
+    (when (coffee-previous-line-is-single-line-comment)
+      (dotimes (i prev-indent)
+        (insert " "))
+      (insert "# "))))
 
 (defun coffee-dedent-line-backspace (arg)
   "Unindent to increment of `coffee-tab-width' with ARG==1 when
@@ -700,7 +702,10 @@ previous line."
     (forward-line -1)
     (back-to-indentation)
     (and (looking-at "#")
-         (not (looking-at "###\\(?:\\s-+.*\\)?$")))))
+         (not (looking-at "###\\(?:\\s-+.*\\)?$"))
+         (progn
+           (goto-char (line-end-position))
+           (nth 4 (syntax-ppss))))))
 
 (defun coffee-indent-shift-amount (start end dir)
   "Compute distance to the closest increment of `coffee-tab-width'."

--- a/test/coffee-command.el
+++ b/test/coffee-command.el
@@ -142,6 +142,19 @@ $('#demo').click ->"
     (back-to-indentation)
     (should (looking-at "^#"))))
 
+(ert-deftest not-insert-hashmark-case ()
+  "Don't insert hashmark if previous line is statement comment"
+  (with-coffee-temp-buffer
+    "
+foo = 10 # bar
+"
+    (forward-cursor-on "bar")
+    (goto-char (line-end-position))
+    (coffee-newline-and-indent)
+
+    (back-to-indentation)
+    (should-not (looking-at "^#"))))
+
 (ert-deftest insert-hashmark-after-single-line-comment-not-three-hashmarks ()
   "Insert hashmark next line of single line comment with not three hashmarks"
   (with-coffee-temp-buffer
@@ -176,6 +189,20 @@ $('#demo').click ->"
 
     (back-to-indentation)
     (should-not (looking-at "^#"))))
+
+(ert-deftest indent-inserted-comment-newline ()
+  "indent next line comment"
+  (with-coffee-temp-buffer
+    "
+    # foo
+"
+    (forward-cursor-on "foo")
+    (let ((prev-indent (current-indentation)))
+      (coffee-newline-and-indent)
+      (back-to-indentation)
+      (should (looking-at "#"))
+      (should-not (zerop (current-indentation)))
+      (should (= prev-indent (current-indentation))))))
 
 ;;
 ;; indent left


### PR DESCRIPTION
`|` is cursor position where `coffee-newline-and-indent` executed.
### Before

``` coffee
   # comment |
# <- not indented
```
### After

``` coffee
   # comment |
   # <- indent same as previous line
```
