### PR TITLE
Improve keyword highlighting

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -440,8 +440,9 @@ called `coffee-compiled-buffer-name'."
 
 ;; Booleans
 (defvar coffee-boolean-regexp
-  (regexp-opt '("true" "false" "yes" "no" "on" "off" "null" "undefined")
-              'words))
+  (concat "\\(?:^\\|[^.]\\)"
+          (regexp-opt '("true" "false" "yes" "no" "on" "off" "null" "undefined")
+                      'words)))
 
 ;; Regular expressions
 (eval-and-compile
@@ -475,10 +476,11 @@ called `coffee-compiled-buffer-name'."
 ;; Regular expression combining the above three lists.
 (defvar coffee-keywords-regexp
   ;; keywords can be member names.
-  (regexp-opt (append coffee-js-reserved
-                      coffee-js-keywords
-                      coffee-cs-keywords
-                      iced-coffee-cs-keywords) 'symbols))
+  (concat "\\(?:^\\|[^.]\\)"
+          (regexp-opt (append coffee-js-reserved
+                              coffee-js-keywords
+                              coffee-cs-keywords
+                              iced-coffee-cs-keywords) 'symbols)))
 
 ;; Create the list for font-lock. Each class of keyword is given a
 ;; particular face.

--- a/test/coffee-highlight.el
+++ b/test/coffee-highlight.el
@@ -355,6 +355,18 @@ foo =
       iced-keyword
       (should (face-at-cursor-p 'font-lock-keyword-face)))))
 
+(ert-deftest keywords-js-keywords-property-name ()
+  "Don't highlight property name whose name is JavaScript keywords"
+
+  (dolist (js-keyword '("if" "else" "new" "return" "try" "catch"
+                        "finally" "throw" "break" "continue" "for" "in" "while"
+                        "delete" "instanceof" "typeof" "switch" "super" "extends"
+                        "class" "until" "loop"))
+    (with-coffee-temp-buffer
+      (format "foo.%s" js-keyword)
+      (forward-cursor-on js-keyword)
+      (should-not (face-at-cursor-p 'font-lock-keyword-face)))))
+
 ;;
 ;; class keywords(#99)
 ;;
@@ -384,6 +396,15 @@ foo =
     (with-coffee-temp-buffer
       keyword
       (should (face-at-cursor-p 'font-lock-constant-face)))))
+
+(ert-deftest boolean-property ()
+  "Don't highlight property name whose name is boolean keyword"
+
+  (dolist (keyword '("true" "false" "yes" "no" "on" "off" "null" "undefined"))
+    (with-coffee-temp-buffer
+      (format "foo.%s" keyword)
+      (forward-cursor-on keyword)
+      (should-not (face-at-cursor-p 'font-lock-constant-face)))))
 
 ;;
 ;; Single line comment


### PR DESCRIPTION
Don't highlight property name whose name equals to reserved keyword.
### Before

![before](https://f.cloud.github.com/assets/554281/1846691/cb5286d0-7611-11e3-97ff-27725df27a50.png)
### After

![after](https://f.cloud.github.com/assets/554281/1846692/cdf47eca-7611-11e3-9fd1-973e8acb107a.png)
