### PR TITLE
Fix block comment highlighting issue(#205)

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -998,7 +998,7 @@ comments such as the following:
   (let ((curpoint (point))
         (inhibit-changing-match-data t))
     (let* ((valid-comment-start nil)
-           (valid-comment-end (looking-at-p "\\s-*$"))
+           (valid-comment-end (looking-at-p "#\\{0,2\\}\\s-*$"))
            (ppss (prog2
                      (backward-char 3)
                      (syntax-ppss)

--- a/test/coffee-highlight.el
+++ b/test/coffee-highlight.el
@@ -524,6 +524,36 @@ myFunction: (callback) =>
     (forward-cursor-on "doStuff")
     (should-not (face-at-cursor-p 'font-lock-comment-face))))
 
+;; #205 -- more hashes
+(ert-deftest block-comment-with-more-hash-marks ()
+  "Highlight block comment whose block ends is more than 3 hash marks"
+  (with-coffee-temp-buffer
+    "
+myFunction: (callback) =>
+    ### This comment ends with to many hashes ####
+    doStuff
+"
+    (forward-cursor-on "doStuff")
+    (should-not (face-at-cursor-p 'font-lock-comment-face))))
+
+(ert-deftest block-comment-with-more-hash-marks2 ()
+  "Highlight block comment whose block ends is more than 3 hash marks another case"
+  (with-coffee-temp-buffer
+    "
+myFunction: (callback) =>
+    ### same
+    here #####
+    doStuff
+"
+    (forward-cursor-on "same")
+    (should (face-at-cursor-p 'font-lock-comment-face))
+
+    (forward-cursor-on "here")
+    (should (face-at-cursor-p 'font-lock-comment-face))
+
+    (forward-cursor-on "doStuff")
+    (should-not (face-at-cursor-p 'font-lock-comment-face))))
+
 ;;
 ;; Regular Expression Tests (#141)
 ;;


### PR DESCRIPTION
Original code assume end of block comment has only 3 hash marks.
But Coffeescript accepts end of hash mark more than 3
