### PR TITLE
Remove unnecessary documentation from coffee-mode-hook

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -209,19 +209,6 @@ with CoffeeScript."
 (defcustom coffee-mode-hook nil
   "Hook called by `coffee-mode'.  Examples:
 
-      ;; CoffeeScript uses two spaces.
-      (make-local-variable 'tab-width)
-      (set 'tab-width 2)
-
-      ;; If you don't want your compiled files to be wrapped
-      (setq coffee-args-compile '(\"-c\" \"--bare\"))
-
-      ;; Emacs key binding
-      (define-key coffee-mode-map [(meta r)] 'coffee-compile-buffer)
-
-      ;; Bleeding edge.
-      (setq coffee-command \"~/dev/coffee\")
-
       ;; Compile '.coffee' files on every save
       (and (file-exists-p (buffer-file-name))
            (file-exists-p (coffee-compiled-file-name))


### PR DESCRIPTION
Such configuration should not be defined in hook,
they should be defined in `eval-after-load`.
