### PR TITLE
Fix source map issue(#212)

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -294,14 +294,13 @@ See `coffee-compile-jump-to-error'."
   (interactive)
   (let* ((input (buffer-file-name))
          (basename (file-name-sans-extension input))
-         (output (if (string-match-p "\\.js\\'" basename)
-                     basename
-                   (concat basename ".js")))
+         (output (when (string-match-p "\\.js\\'" basename) ;; for Rails '.js.coffee' file
+                   basename))
          (compile-cmd (coffee-command-compile input output))
          (compiler-output (shell-command-to-string compile-cmd)))
     (if (string= compiler-output "")
         (let ((file-name (coffee-compiled-file-name (buffer-file-name))))
-          (message "Compiled and saved %s" output)
+          (message "Compiled and saved %s" (or output (concat basename ".js")))
           (coffee-revert-buffer-compiled-file file-name))
       (let* ((msg (car (split-string compiler-output "[\n\r]+")))
              (line (when (string-match "on line \\([0-9]+\\)" msg)


### PR DESCRIPTION
We should not specify '-j' option for compiling to JavaScript.
It should be used only Rails '.js.coffee' file for avoiding
'.js.js' file generated.

If you want to generate source map file in Rails project,
please see following project.

  https://github.com/markbates/coffee-rails-source-maps

CC: @tomfaulhaber
