### PR TITLE
Workaround for ansi colors in a repl.

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -269,9 +269,11 @@ with CoffeeScript."
             coffee-args-repl))
 
     ;; Workaround: https://github.com/defunkt/coffee-mode/issues/30
+    ;; Workaround for ansi colors
     (set (make-local-variable 'comint-preoutput-filter-functions)
          (cons (lambda (string)
-                 (replace-regexp-in-string "\x1b\\[.[GJK]" "" string)) nil)))
+                 (replace-regexp-in-string "\x1b\\[.[GJK]" "" string))
+               (cons 'ansi-color-apply nil))))
 
   (pop-to-buffer coffee-repl-buffer))
 


### PR DESCRIPTION
When used with `iced` repl terminal colors are printed as raw escape sequences. This change turn them into proper colors. Alternatively one can replace `ansi-color-apply` with `ansi-color-filter-apply` for color-less output. For more details: http://www.emacswiki.org/emacs/AnsiColor
