### PR TITLE
remove electric-pair-delete-pair

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -137,8 +137,6 @@
 
 (require 'cl-lib)
 
-(declare-function electric-pair-delete-pair "elec-pair")
-
 ;;
 ;; Customizable Variables
 ;;
@@ -714,12 +712,8 @@ Delete ARG spaces if ARG!=1."
              (deleted-chars (if (zerop extra-space-count)
                                 coffee-tab-width
                               extra-space-count)))
-        (if (and electric-pair-mode (featurep 'elec-pair))
-            (electric-pair-delete-pair deleted-chars)
-          (backward-delete-char-untabify deleted-chars)))
-    (if (and electric-pair-mode (featurep 'elec-pair))
-        (electric-pair-delete-pair arg)
-      (backward-delete-char-untabify arg))))
+        (backward-delete-char-untabify deleted-chars))
+    (backward-delete-char-untabify arg)))
 
 ;; Indenters help determine whether the current line should be
 ;; indented further based on the content of the previous line. If a


### PR DESCRIPTION
I also noticed the function `electric-pair-backward-delete-char-untabify` was removed in the latest prelease builds of 24.4 but PR #235 actually breaks electric-pair compatibility. It makes every backspace run the delete pair function with no consideration of whether it is between a pair or not.

Luckily, the re-write of `elec-pair` in 24.4 is more unobtrusive so none of this is needed now for the desired backspace behavior.
