### PR TITLE
Fix js2coffee-replace-region when mark is after point

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -424,9 +424,8 @@ called `coffee-compiled-buffer-name'."
       (kill-buffer buffer)))
 
   (call-process-region start end
-                       js2coffee-command nil
-                       (current-buffer))
-  (delete-region start end))
+                       js2coffee-command t
+                       (current-buffer)))
 
 (defun coffee-version ()
   "Show the `coffee-mode' version in the echo area."


### PR DESCRIPTION
When the mark is after the point, calling js2coffee-replace-region doesn't give the desired output and generally results with the original js code with a few characters deleted.

This is because call-process-region inserts the output in the buffer before the point, and then delete-region ends up deleting the resulting coffee code.

call-process-region already has an option of providing a fourth non-nil argument to delete the text between start and end.
