### PR TITLE
Fix case that first evaluation is not multiple lines

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -423,8 +423,8 @@ called `coffee-compiled-buffer-name'."
             (comint-simple-send proc string)
             (unless (string-match-p "\n\\'" string)
               (comint-send-string proc "\n"))
-            (comint-send-string proc multiline-code)
-            (setq coffee--repl-multiline-initialized t)))))))
+            (comint-send-string proc multiline-code))))
+      (setq coffee--repl-multiline-initialized t))))
 
 (defun coffee-send-buffer ()
   "Send the current buffer to the inferior Coffee process."


### PR DESCRIPTION
'C-vC-v' is necessary only first time evaluation
regardless of one line or multiple lines.

Related to #253 
