### PR TITLE
Variable name fix

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -625,7 +625,7 @@ output in a compilation buffer."
           "\\|"
           coffee-namespace-regexp ; $4
           "\\|"
-          "\\(@?[[:word:]:.$]+\\)\\s-*=\\(?:[^>]\\|$\\)" ; $5 match prototype access too
+          "\\(@?[_[:word:]:.$]+\\)\\s-*=\\(?:[^>]\\|$\\)" ; $5 match prototype access too
           "\\(?:" "\\s-*" "\\(" coffee-lambda-regexp "\\)" "\\)?" ; $6
           "\\)"))
 

--- a/test/coffee-syntax.el
+++ b/test/coffee-syntax.el
@@ -25,16 +25,26 @@
 (require 'coffee-mode)
 
 ;;
-;; Treat "_" as `word'
+;; Treat variables with "_" as word delimiters
 ;;
-(ert-deftest treat-underscore-as-word ()
-  "Treat \"_\" as word"
+(ert-deftest treat-underscores-within-variables-as-symbols ()
+  "Treat '_' within variable names as word delimiters"
   (with-coffee-temp-buffer
     "foo_bar"
+    (forward-word 1)
+    (forward-cursor-on "_")
+    (should (not (eobp)))
+
     (forward-word 1)
     (should (eobp))
 
     (backward-word 1)
+    (should (not (bobp)))
+    (forward-cursor-on "bar")
+    (backward-cursor-on "foo")
+
+    (backward-word 1)
+    (forward-cursor-on "foo")
     (should (bobp))))
 
 ;;


### PR DESCRIPTION
This change adds a fix for variable names which contain underscores.

Previously '_' were incorrectly treated as words, so word navigation: <kbd>M-f</kbd> & <kbd>M-b</kbd> would incorrectly jump over, partially or completely, over the variables with underscores in their names.

Most of the discussion that went about this change can be found under this issue: #265 
