### PR TITLE
Fix class attribute highlighting that contain underscores

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -500,7 +500,7 @@ called `coffee-compiled-buffer-name'."
 (defvar coffee-prototype-regexp "[[:word:].$]+?::")
 
 ;; Assignment
-(defvar coffee-assign-regexp "\\(@?[[:word:].$]+?\\)\\s-*:")
+(defvar coffee-assign-regexp "\\(@?[_[:word:].$]+?\\)\\s-*:")
 
 ;; Local Assignment
 (defvar coffee-local-assign-regexp "\\s-*\\([_[:word:].$]+\\)\\s-*=\\(?:[^>=]\\|$\\)")


### PR DESCRIPTION
Currently coffee-mode only highlights the last word of a class property.

``` coffeescript
  class ChildView extends ParentView
    ONLY_LAST_WORD_HIGHLIGHTED: /^((\s|\n)*\$\$)/g
```

@syohex sorry for the duplicate PR, I had the wrong git config on the first PR.
