### PR TITLE
Initial implement multiline regexp

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -1140,16 +1140,16 @@ comments such as the following:
   (defconst coffee-block-strings-delimiter
     (rx (and
          ;; Match even number of backslashes.
-         (or (not (any ?\\ ?\' ?\"))
+         (or (not (any ?\\ ?\' ?\" ?/))
              point
              ;; Quotes might be preceded by a escaped quote.
              (and (or (not (any ?\\)) point)
                   ?\\
                   (* ?\\ ?\\)
-                  (any ?\' ?\")))
+                  (any ?\' ?\" ?/)))
          (* ?\\ ?\\)
          ;; Match single or triple quotes of any kind.
-         (group (or "'''" "\"\"\""))))))
+         (group (or "'''" "\"\"\"" "///"))))))
 
 (defsubst coffee-syntax-count-quotes (quote-char start-point limit)
   (let ((i 0))

--- a/test/coffee-highlight.el
+++ b/test/coffee-highlight.el
@@ -939,6 +939,32 @@ block-strings-end
     (should-not (face-at-cursor-p 'font-lock-string-face))
     (should (or (face-at-cursor-p nil)  (face-at-cursor-p 'default)))))
 
+(ert-deftest block-regex ()
+  "Multiple line regex"
+  (with-coffee-temp-buffer
+    "
+OPERATOR = /// ^ (
+  ?: [-=]>             # function
+   | [-+*/%<>&|^!?=]=  # compound assign / compare
+   | >>>=?             # zero-fill right shift
+   | ([-+:])\1         # doubles
+   | ([&|<>])\2=?      # logic / shift
+   | \?\.              # soak access
+   | \.{2,3}           # range or splat
+) ///
+after = 1
+"
+    (forward-cursor-on "\\^ ")
+    (should (face-at-cursor-p 'font-lock-string-face))
+
+    (forward-cursor-on "\\?:")
+    (should (face-at-cursor-p 'font-lock-string-face))
+
+    (forward-cursor-on "after")
+    (should-not (face-at-cursor-p 'font-lock-string-face))))
+
+;;; Regression test
+
 (ert-deftest regression-272 ()
   "Regression test for #272"
   (with-coffee-temp-buffer


### PR DESCRIPTION
Current `coffee-mode` cannot highlight multiple lines regexp listeral(`///` ... `///`) and
its broken syntax highlighting of entire file. This change makes highlighting multiple lines
regexp literal same as string. Ideally it is highlighted same as single line regexp liteal(`/regexp/`),
but it is impossible with current design of `coffee-mode`.

![coffee-multiple-regexp](https://cloud.githubusercontent.com/assets/554281/6283015/97cedbb6-b921-11e4-89ea-bc557b23c02e.png)
