### PR TITLE
Fix highlight member variable if it contains underscore

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -494,7 +494,7 @@ called `coffee-compiled-buffer-name'."
 ;;
 
 ;; Instance variables (implicit this)
-(defvar coffee-this-regexp "\\(?:@\\w+\\|\\<this\\)\\>")
+(defvar coffee-this-regexp "\\(?:@[_[:word:]]+\\|\\<this\\)\\>")
 
 ;; Prototype::access
 (defvar coffee-prototype-regexp "[_[:word:].$]+?::")

--- a/test/coffee-highlight.el
+++ b/test/coffee-highlight.el
@@ -1056,4 +1056,12 @@ testMethod = (id) ->
     (forward-cursor-on "Broken")
     (should (face-at-cursor-p 'font-lock-comment-face))))
 
+(ert-deftest regression-304 ()
+  "Broken syntax highlighting if class member name contains underscore"
+  (with-coffee-temp-buffer
+    "@proto_classes = builder.build"
+
+    (forward-cursor-on "classes")
+    (should (face-at-cursor-p 'font-lock-variable-name-face))))
+
 ;;; coffee-highlight.el end here


### PR DESCRIPTION
This is related to #304.