### PR TITLE
Add a small helper to toggle the enclosing scope / fatness of a function

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -529,6 +529,15 @@ output in a compilation buffer."
            (generate-new-buffer-name coffee-compiled-buffer-name))))
     (compile (concat coffee-command " " args))))
 
+(defun coffee-toggle-fatness ()
+  "Toggle fatness of a coffee function arrow."
+  (interactive)
+  (save-excursion
+    (ignore-errors
+      (re-search-backward "[-=]>" )
+      (when (looking-at "=") (replace-match "-"))
+      (when (looking-at "-") (replace-match "=")))))
+
 ;;
 ;; imenu support
 ;;


### PR DESCRIPTION
Not sure if this sort of thing belongs in coffee-mode or we need a coffee-mode+.el ... 