### PR TITLE
fix lambda regexp

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -406,7 +406,7 @@ called `coffee-compiled-buffer-name'."
 (defvar coffee-local-assign-regexp "\\s-*\\([_[:word:].$]+\\)\\s-*\\??=\\(?:[^>=]\\|$\\)")
 
 ;; Lambda
-(defvar coffee-lambda-regexp "\\(?:(.*)\\)?\\s-*\\(->\\|=>\\)")
+(defvar coffee-lambda-regexp "\\(?:([^)]*)\\)?\\s-*\\(->\\|=>\\)")
 
 ;; Namespaces
 (defvar coffee-namespace-regexp "\\b\\(?:class\\s-+\\(\\S-+\\)\\)\\b")


### PR DESCRIPTION
Add guard in regexp to allow multiple lambdas on one line.

Previously, `(a) -> (b) ->` would match `(a)` with `b`'s arrow, resulting in `a`'s arrow not getting highlighted by `font-lock`. This fixes the issue, and shouldn't create any more problems (it handles lambdas as default arguments, e.g. `a = (f = (b) ->) ->` as well).

old:
![old buggy version](http://i.imgur.com/7bAraVR.png)
new:
![new fixed version](http://i.imgur.com/NhQ3Lg1.png)

If you look closely and check what it matches for the string `a = (f = (b) ->) ->`, it really doesn't handle lambdas as default arguments appropriately (it should be using a backreference), but it still works:
![nested lambda example](https://i.imgur.com/16v4MEN.png)