### PR TITLE
modifications to compiling buffer or region

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -284,7 +284,6 @@ called `coffee-compiled-buffer-name'."
             (let ((buffer-file-name "tmp.js"))
               (setq buffer-read-only t)
               (set-auto-mode)
-              (forward-line 1) ;; 1st line is comment
               (run-hook-with-args 'coffee-after-compile-hook props))))))))
 
 (defun coffee-start-compile-process (curbuf line column)

--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -131,6 +131,12 @@ with CoffeeScript."
   :type 'boolean
   :group 'coffee)
 
+(defcustom coffee-switch-to-compile-buffer nil
+  "Switch to compilation buffer `coffee-compiled-buffer-name' after compiling
+a buffer or region."
+  :type 'boolean
+  :group 'coffee)
+
 (defvar coffee-mode-map
   (let ((map (make-sparse-keymap)))
     ;; key bindings
@@ -260,10 +266,14 @@ called `coffee-compiled-buffer-name'."
     ;; foo.js: foo.js.map(>= 1.8), foo.map(< 1.8)
     (concat (file-name-sans-extension coffee-file) extension)))
 
+(defmacro coffee-save-window-if (bool &rest body)
+  `(if ,bool (save-selected-window ,@body) ,@body))
+(put 'coffee-save-window-if 'lisp-indent-function 1)
+
 (defun coffee-compile-sentinel (file line column)
   (lambda (proc _event)
     (when (eq (process-status proc) 'exit)
-      (save-selected-window
+      (coffee-save-window-if (not coffee-switch-to-compile-buffer)
         (pop-to-buffer (get-buffer coffee-compiled-buffer-name))
         (ansi-color-apply-on-region (point-min) (point-max))
         (goto-char (point-min))


### PR DESCRIPTION
Add `defcustom` for switching to the compiled buffer after compiling a buffer or region. Also remove `(forward-line 1)` in sentinel because it's not helpful (check commit for details).