### PR TITLE
fix coffee-send-region truncation

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -327,7 +327,9 @@ called `coffee-compiled-buffer-name'."
 
 (defun coffee-get-repl-proc ()
   (unless (comint-check-proc coffee-repl-buffer)
-    (coffee-repl))
+    (coffee-repl)
+    ;; see issue #332
+    (sleep-for 0 100))
   (get-buffer-process coffee-repl-buffer))
 
 (defun coffee-send-line ()


### PR DESCRIPTION
Adds a `sleep-for` timeout to `coffee-get-repl-proc`, if it has to create the repl process. This avoids the early truncation issue described in #332, on my system.