### PR TITLE
fix filling of inline and multiline comments

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -1200,11 +1200,14 @@ comments such as the following:
 (defun coffee-get-comment-info ()
   (let* ((syntax (syntax-ppss))
          (commentp (nth 4 syntax))
-         (comment-start (nth 8 syntax)))
+         (comment-start-kinda (nth 8 syntax)))
     (when commentp
       (save-excursion
-        (if (string=
-             "###" (buffer-substring (- comment-start 2) (1+ comment-start)))
+        (if (and
+             (> comment-start-kinda 2) (< comment-start-kinda (point-max))
+             (string=
+              "###" (buffer-substring
+                     (- comment-start-kinda 2) (1+ comment-start-kinda))))
             'multiple-line
           'single-line)))))
 

--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -1212,7 +1212,8 @@ comments such as the following:
           'single-line)))))
 
 (defun coffee-comment-line-break-fn (&optional _)
-  (let ((comment-type (coffee-get-comment-info)))
+  (let ((comment-type (coffee-get-comment-info))
+        (coffee-indent-like-python-mode t))
     (comment-indent-new-line)
     (cond ((eq comment-type 'multiple-line)
            (save-excursion
@@ -1224,7 +1225,8 @@ comments such as the following:
 
 (defun coffee-auto-fill-fn ()
   (let ((comment-type (coffee-get-comment-info))
-         (fill-result (do-auto-fill)))
+        (fill-result (do-auto-fill))
+        (coffee-indent-like-python-mode t))
     (when (and fill-result (eq comment-type 'single-line))
       (save-excursion
         (beginning-of-line)

--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -1205,11 +1205,11 @@ comments such as the following:
       (save-excursion
         (if (string=
              "###" (buffer-substring (- comment-start 2) (1+ comment-start)))
-            (list :type 'multiple-line :start (- comment-start 2))
-          (list :type 'single-line :start comment-start))))))
+            'multiple-line
+          'single-line)))))
 
 (defun coffee-comment-line-break-fn (&optional _)
-  (let ((comment-type (plist-get (coffee-get-comment-info) :type)))
+  (let ((comment-type (coffee-get-comment-info)))
     (comment-indent-new-line)
     (cond ((eq comment-type 'multiple-line)
            (save-excursion
@@ -1220,7 +1220,7 @@ comments such as the following:
            (coffee-indent-line)))))
 
 (defun coffee-auto-fill-fn ()
-  (let* ((comment-type (plist-get (coffee-get-comment-info) :type))
+  (let ((comment-type (coffee-get-comment-info))
          (fill-result (do-auto-fill)))
     (when (and fill-result (eq comment-type 'single-line))
       (save-excursion
@@ -1241,8 +1241,9 @@ comments such as the following:
   (setq font-lock-defaults '((coffee-font-lock-keywords)))
 
   ;; fix comment filling function
-  (setq-local comment-line-break-function #'coffee-comment-line-break-fn)
-  (setq-local auto-fill-function #'coffee-auto-fill-fn)
+  (setq (make-local-variable 'comment-line-break-function)
+        #'coffee-comment-line-break-fn)
+  (setq (make-local-variable 'auto-fill-function) #'coffee-auto-fill-fn)
   ;; perl style comment: "# ..."
   (modify-syntax-entry ?# "< b" coffee-mode-syntax-table)
   (modify-syntax-entry ?\n "> b" coffee-mode-syntax-table)

--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -1197,6 +1197,38 @@ comments such as the following:
      (0 (ignore (coffee-syntax-propertize-block-comment)))))
    (point) end))
 
+(defun coffee-get-comment-info ()
+  (let* ((syntax (syntax-ppss))
+         (commentp (nth 4 syntax))
+         (comment-start (nth 8 syntax)))
+    (when commentp
+      (save-excursion
+        (if (string=
+             "###" (buffer-substring (- comment-start 2) (1+ comment-start)))
+            (list :type 'multiple-line :start (- comment-start 2))
+          (list :type 'single-line :start comment-start))))))
+
+(defun coffee-comment-line-break-fn (&optional _)
+  (let ((comment-type (plist-get (coffee-get-comment-info) :type)))
+    (comment-indent-new-line)
+    (cond ((eq comment-type 'multiple-line)
+           (save-excursion
+             (beginning-of-line)
+             (when (looking-at "[[:space:]]*\\(#\\)")
+               (replace-match "" nil nil nil 1))))
+          ((eq comment-type 'single-line)
+           (coffee-indent-line)))))
+
+(defun coffee-auto-fill-fn ()
+  (let* ((comment-type (plist-get (coffee-get-comment-info) :type))
+         (fill-result (do-auto-fill)))
+    (when (and fill-result (eq comment-type 'single-line))
+      (save-excursion
+        (beginning-of-line)
+        (when (looking-at "[[:space:]]*#")
+          (replace-match "#")))
+      (coffee-indent-line))))
+
 ;;
 ;; Define Major Mode
 ;;
@@ -1208,6 +1240,9 @@ comments such as the following:
   ;; code for syntax highlighting
   (setq font-lock-defaults '((coffee-font-lock-keywords)))
 
+  ;; fix comment filling function
+  (setq-local comment-line-break-function #'coffee-comment-line-break-fn)
+  (setq-local auto-fill-function #'coffee-auto-fill-fn)
   ;; perl style comment: "# ..."
   (modify-syntax-entry ?# "< b" coffee-mode-syntax-table)
   (modify-syntax-entry ?\n "> b" coffee-mode-syntax-table)

--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -1241,9 +1241,9 @@ comments such as the following:
   (setq font-lock-defaults '((coffee-font-lock-keywords)))
 
   ;; fix comment filling function
-  (setq (make-local-variable 'comment-line-break-function)
+  (set (make-local-variable 'comment-line-break-function)
         #'coffee-comment-line-break-fn)
-  (setq (make-local-variable 'auto-fill-function) #'coffee-auto-fill-fn)
+  (set (make-local-variable 'auto-fill-function) #'coffee-auto-fill-fn)
   ;; perl style comment: "# ..."
   (modify-syntax-entry ?# "< b" coffee-mode-syntax-table)
   (modify-syntax-entry ?\n "> b" coffee-mode-syntax-table)


### PR DESCRIPTION
Auto filling was failing in these two cases (`|` is the position of point):

1) When in a multiline comment (`###` comment), auto-filling the line resulted in the next line having a `#` prepended to it; this is fixed by this pr.

Failing case:
``` coffeescript
###
<some text up to fill-column>|
###
```

2) When in an inline comment, indentation doesn't work correctly (the `#` of each line isn't aligned correctly). This fix calls `coffee-indent-line` so they are aligned correctly.

Failing case:
``` coffeescript
someFunction someArgument # <comment on function that goes to fill-column>|
```

Also, `coffee-in-comment-p` is incorrect, because it checks `(syntax-ppss)` after moving point, and I would change it to use `coffee-get-comment-info`, but I don't want to break other things that might rely on it.