### PR TITLE
Add "when" to coffee-indenters-bol

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -795,7 +795,7 @@ Delete ARG spaces if ARG!=1."
 ;; want to indent the next line.
 
 (defvar coffee-indenters-bol '("class" "for" "if" "else" "unless" "while" "until"
-                               "try" "catch" "finally" "switch")
+                               "try" "catch" "finally" "switch" "when")
   "Keywords or syntax whose presence at the start of a line means the
 next line should probably be indented.")
 


### PR DESCRIPTION
At least according to the example on http://coffeescript.org/#switch , when should also cause the next line to be indented. Not sure if this was something that was rejected or just an oversight. Thanks!