### PR TITLE
Add : to coffee-indenters-eol

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -803,7 +803,7 @@ next line should probably be indented.")
   "Builds a regexp out of `coffee-indenters-bol' words."
   (regexp-opt coffee-indenters-bol 'words))
 
-(defvar coffee-indenters-eol '(?> ?{ ?\[)
+(defvar coffee-indenters-eol '(?> ?{ ?\[ ?:)
   "Single characters at the end of a line that mean the next line
 should probably be indented.")
 


### PR DESCRIPTION
According to http://coffeescript.org/#objects_and_arrays , when writing nested object literals you should indent the child object further. I think the only place : could end a line would be nested object literals, correct? Haven't thought this one completely through but I think this should be more correct.