### PR TITLE
Use normal-auto-fill-function for not enabling auto-fill-mode

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -1248,7 +1248,7 @@ comments such as the following:
   ;; fix comment filling function
   (set (make-local-variable 'comment-line-break-function)
         #'coffee-comment-line-break-fn)
-  (set (make-local-variable 'auto-fill-function) #'coffee-auto-fill-fn)
+  (set (make-local-variable 'normal-auto-fill-function) #'coffee-auto-fill-fn)
   ;; perl style comment: "# ..."
   (modify-syntax-entry ?# "< b" coffee-mode-syntax-table)
   (modify-syntax-entry ?\n "> b" coffee-mode-syntax-table)


### PR DESCRIPTION
If auto-fill-function is set, then auto-fill-mode is enabled
automatically. Everyone does not expect this behavior.

This is related to #341.
CC: @taylorzane 