### PR TITLE
Send newline for ensuring compiling code

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -302,6 +302,7 @@ called `coffee-compiled-buffer-name'."
        proc (coffee-compile-sentinel curbuf curfile line column))
       (with-current-buffer curbuf
         (process-send-region proc start end))
+      (process-send-string proc "\n")
       (process-send-eof proc))))
 
 (defun coffee-start-generate-sourcemap-process (start end)


### PR DESCRIPTION
Because coffee command does not generate JS code, if region does not end
with newline.

This is related to #340.
CC: @dmh43