### PR TITLE
Fix indentation after oneline if/while/when

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -814,7 +814,8 @@ previous line."
       (or (and char-of-eol (memq char-of-eol coffee-indenters-eol))
           (progn
             (back-to-indentation)
-            (looking-at (coffee-indenters-bol-regexp)))))))
+            (and (looking-at (coffee-indenters-bol-regexp))
+                 (not (re-search-forward "\\_<then\\_>" (line-end-position) t))))))))
 
 (defun coffee-previous-line-is-single-line-comment ()
   "Return t if the previous line is a CoffeeScript single line comment."

--- a/test/coffee-command.el
+++ b/test/coffee-command.el
@@ -1519,4 +1519,27 @@ foo = () ->
    (goto-char (line-end-position))
    (should (looking-back "->"))))
 
+(ert-deftest regression-350-if-then-oneline ()
+  "https://github.com/defunkt/coffee-mode/issues/350"
+
+  (let ((coffee-tab-width 2))
+    (with-coffee-temp-buffer
+      "
+if x then y
+
+switch x
+  when y then z
+new_line = 'here'
+"
+      (forward-cursor-on "if")
+      (goto-char (line-end-position))
+      (call-interactively #'coffee-newline-and-indent)
+      (should (= (current-indentation) 0))
+
+      (forward-cursor-on "when")
+      (let ((prev-indent (current-indentation)))
+        (goto-char (line-end-position))
+        (call-interactively #'coffee-newline-and-indent)
+        (should (= (current-indentation) prev-indent))))))
+
 ;;; coffee-command.el end here


### PR DESCRIPTION
This is related to #350.
CC: @Spadavecchia 