### PR TITLE
Replace set-auto-mode with custom function

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -112,6 +112,10 @@ with CoffeeScript."
   "Indentation can insert tabs if this is t."
   :type 'boolean)
 
+(defcustom coffee-show-mode 'js-mode
+  "Major mode to used to show the compiled Javascript."
+  :type 'function)
+
 (defcustom coffee-after-compile-hook nil
   "Hook called after compile to Javascript"
   :type 'hook)
@@ -280,10 +284,10 @@ called `coffee-compiled-buffer-name'."
                 (coffee-parse-error-output compile-output)))
           (let ((props (list :sourcemap (coffee--map-file-name file)
                              :line line :column column :source file)))
-            (let ((buffer-file-name "tmp.js"))
-              (setq buffer-read-only t)
-              (set-auto-mode)
-              (run-hook-with-args 'coffee-after-compile-hook props))))))))
+            (setq buffer-read-only t)
+            (when (fboundp coffee-show-mode)
+              (funcall coffee-show-mode))
+            (run-hook-with-args 'coffee-after-compile-hook props)))))))
 
 (defun coffee-start-compile-process (curbuf line column)
   (lambda (start end)


### PR DESCRIPTION
Use a custom mode for showing the compiled javascript. Overwriting `buffer-file-name` can cause problems for other packages; for example, tern.el starts the server only with [`buffer-file-name` is set](https://github.com/ternjs/tern/blob/a5a5ba61ae3a555c1a3a155764cb403a39a7ee6c/emacs/tern.el#L55), and coffee set it `tmp.js` which doesn't exists.