### PR TITLE
Operators should be not be seemed as part of a symbol.

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -1250,6 +1250,9 @@ comments such as the following:
     ;; Treat slashes as paired delimiters; useful for finding regexps.
     (modify-syntax-entry ?/ "/" table)
 
+    ;; = is not a part of a symbol
+    (modify-syntax-entry ?= "." table)
+
     ;; single quote strings
     (modify-syntax-entry ?' "\"" table)
     table))

--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -1250,8 +1250,17 @@ comments such as the following:
     ;; Treat slashes as paired delimiters; useful for finding regexps.
     (modify-syntax-entry ?/ "/" table)
 
-    ;; = is not a part of a symbol
+    ;; Following chars (=, +, -, ...) should be seemes as operators,
+    ;; instead of a part of a symbol
     (modify-syntax-entry ?= "." table)
+    (modify-syntax-entry ?+ "." table)
+    (modify-syntax-entry ?- "." table)
+    (modify-syntax-entry ?* "." table)
+    (modify-syntax-entry ?& "." table)
+    (modify-syntax-entry ?% "." table)
+    (modify-syntax-entry ?| "." table)
+    (modify-syntax-entry ?> "." table)
+    (modify-syntax-entry ?< "." table)
 
     ;; single quote strings
     (modify-syntax-entry ?' "\"" table)


### PR DESCRIPTION
e.g. 
```coffee
foo='bar'
```
`foo` should be seemed as a symbol (token) by Emacs's syntax engine, instead of `foo=`