### PR TITLE
Highlight "as" and "from" as keywords

### DIFF
--- a/coffee-mode.el
+++ b/coffee-mode.el
@@ -457,7 +457,7 @@ called `coffee-compiled-buffer-name'."
 (defvar coffee-js-reserved
   '("case" "default" "do" "function" "var" "void" "with"
     "const" "let" "debugger" "enum" "export" "import" "native"
-    "__extends" "__hasProp"))
+    "from" "as" "__extends" "__hasProp"))
 
 ;; CoffeeScript keywords.
 (defvar coffee-cs-keywords


### PR DESCRIPTION
This highlights coffeescript 2.x import statements such as `import {debounce as _debounce} from "lodash"` correctly